### PR TITLE
Edited SVR3 Check

### DIFF
--- a/SMAPI/ModEntry.cs
+++ b/SMAPI/ModEntry.cs
@@ -379,11 +379,15 @@ namespace ichortower_HatMouseLacey
                     e.NewStage == LoadStage.SaveLoadedBasicInfo) {
                 try {
                     var modInfo = HML.ModHelper.ModRegistry.Get("DaisyNiko.SVR3");
-                    var modPath = (string)modInfo.GetType().GetProperty("DirectoryPath")
-                        .GetValue(modInfo);
-                    var jConfig = JObject.Parse(File.ReadAllText(Path.Combine(modPath, "config.json")));
-                    var forest = jConfig.GetValue("Forest").Value<string>();
-                    ModEntry.CompatSVR3Forest = (forest == "on");
+                    if (modInfo is null) ModEntry.CompatSVR3Forest = false;
+                    else
+                    {
+                        var modPath = (string)modInfo.GetType().GetProperty("DirectoryPath")
+                          .GetValue(modInfo);
+                        var jConfig = JObject.Parse(File.ReadAllText(Path.Combine(modPath, "config.json")));
+                        var forest = jConfig.GetValue("Forest").Value<string>();
+                        ModEntry.CompatSVR3Forest = (forest == "on");
+                    }
                 }
                 catch {
                     ModEntry.CompatSVR3Forest = false;


### PR DESCRIPTION
Checks if SVRC ModInfo is null and adjusts compatibility as such, rather than catching an exception.

Noticed it when I was debugging another mod, this way the code won't crash into an exception, stopping the debugger to alert you about the error :)